### PR TITLE
Reverse-engineer MTK IRadio interfaces to approve incoming call for MTK devices from Telephony F/W.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -29,6 +29,8 @@ LOCAL_JAVA_LIBRARIES := voip-common ims-common services bouncycastle
 LOCAL_STATIC_JAVA_LIBRARIES := android.hardware.radio-V1.1-java-static \
     android.hardware.radio.deprecated-V1.0-java-static
 
+LOCAL_STATIC_JAVA_LIBRARIES += vendor.mediatek.hardware.radio-V2.0-java-static
+
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := telephony-common
 LOCAL_PROTOC_OPTIMIZE_TYPE := nano

--- a/src/java/com/android/internal/telephony/MtkRadioIndication.java
+++ b/src/java/com/android/internal/telephony/MtkRadioIndication.java
@@ -1,0 +1,481 @@
+package com.android.internal.telephony;
+
+import android.hardware.radio.V1_0.SetupDataCallResult;
+
+import java.util.ArrayList;
+
+import vendor.mediatek.hardware.radio.V2_0.IRadioIndication;
+import vendor.mediatek.hardware.radio.V2_0.IncomingCallNotification;
+import vendor.mediatek.hardware.radio.V2_0.MtkSetupDataCallResult;
+
+public class MtkRadioIndication extends IRadioIndication.Stub {
+    RIL mRil;
+    RadioIndication mIndication;
+
+    MtkRadioIndication(RIL ril, RadioIndication indication) {
+        mRil = ril;
+        mIndication = indication;
+    }
+
+    //++ Radio V1_0
+    public void radioStateChanged(int type, int radioState) {
+        mIndication.radioStateChanged(type, radioState);
+    }
+
+    public void callStateChanged(int type) {
+        mIndication.callStateChanged(type);
+    }
+
+    public void networkStateChanged(int type) {
+        mIndication.networkStateChanged(type);
+    }
+
+    public void newSms(int type, ArrayList<Byte> pdu) {
+        mIndication.newSms(type, pdu);
+    }
+
+    public void newSmsStatusReport(int type, ArrayList<Byte> pdu) {
+        mIndication.newSmsStatusReport(type, pdu);
+    }
+
+    public void newSmsOnSim(int type, int recordNumber) {
+        mIndication.newSmsOnSim(type, recordNumber);
+    }
+
+    public void onUssd(int type, int modeType, String msg) {
+        mIndication.onUssd(type, modeType, msg);
+    }
+
+    public void nitzTimeReceived(int type, String nitzTime, long receivedTime) {
+        mIndication.nitzTimeReceived(type, nitzTime, receivedTime);
+    }
+
+    public void currentSignalStrength(int type, android.hardware.radio.V1_0.SignalStrength signalStrength) {
+        mIndication.currentSignalStrength(type, signalStrength);
+    }
+
+    public void dataCallListChanged(int type, ArrayList<SetupDataCallResult> dcList) {
+        mIndication.dataCallListChanged(type, dcList);
+    }
+
+    public void suppSvcNotify(int type, android.hardware.radio.V1_0.SuppSvcNotification suppSvc) {
+        mIndication.suppSvcNotify(type, suppSvc);
+    }
+
+    public void stkSessionEnd(int type) {
+        mIndication.stkSessionEnd(type);
+    }
+
+    public void stkProactiveCommand(int type, String cmd) {
+        mIndication.stkProactiveCommand(type, cmd);
+    }
+
+    public void stkEventNotify(int type, String cmd) {
+        mIndication.stkEventNotify(type, cmd);
+    }
+
+    public void stkCallSetup(int type, long timeout) {
+        mIndication.stkCallSetup(type, timeout);
+    }
+
+    public void simSmsStorageFull(int type) {
+        mIndication.simSmsStorageFull(type);
+    }
+
+    public void simRefresh(int type, android.hardware.radio.V1_0.SimRefreshResult refreshResult) {
+        mIndication.simRefresh(type, refreshResult);
+    }
+
+    public void callRing(int type, boolean isGsm, android.hardware.radio.V1_0.CdmaSignalInfoRecord record) {
+        mIndication.callRing(type, isGsm, record);
+    }
+
+    public void simStatusChanged(int type) {
+        mIndication.simStatusChanged(type);
+    }
+
+    public void cdmaNewSms(int type, android.hardware.radio.V1_0.CdmaSmsMessage msg) {
+        mIndication.cdmaNewSms(type, msg);
+    }
+
+    public void newBroadcastSms(int type, ArrayList<Byte> data) {
+        mIndication.newBroadcastSms(type, data);
+    }
+
+    public void cdmaRuimSmsStorageFull(int type) {
+        mIndication.cdmaRuimSmsStorageFull(type);
+    }
+
+    public void restrictedStateChanged(int type, int state) {
+        mIndication.restrictedStateChanged(type, state);
+    }
+
+    public void enterEmergencyCallbackMode(int type) {
+        mIndication.enterEmergencyCallbackMode(type);
+    }
+
+    public void cdmaCallWaiting(int type, android.hardware.radio.V1_0.CdmaCallWaiting callWaitingRecord) {
+        mIndication.cdmaCallWaiting(type, callWaitingRecord);
+    }
+
+    public void cdmaOtaProvisionStatus(int type, int status) {
+        mIndication.cdmaOtaProvisionStatus(type, status);
+    }
+
+    public void cdmaInfoRec(int type, android.hardware.radio.V1_0.CdmaInformationRecords records) {
+        mIndication.cdmaInfoRec(type, records);
+    }
+
+    public void indicateRingbackTone(int type, boolean start) {
+        mIndication.indicateRingbackTone(type, start);
+    }
+
+    public void resendIncallMute(int type) {
+        mIndication.resendIncallMute(type);
+    }
+
+    public void cdmaSubscriptionSourceChanged(int type, int cdmaSource) {
+        mIndication.cdmaSubscriptionSourceChanged(type, cdmaSource);
+    }
+
+    public void cdmaPrlChanged(int type, int version) {
+        mIndication.cdmaPrlChanged(type, version);
+    }
+
+    public void exitEmergencyCallbackMode(int type) {
+        mIndication.exitEmergencyCallbackMode(type);
+    }
+
+    public void rilConnected(int type) {
+        mIndication.rilConnected(type);
+    }
+
+    public void voiceRadioTechChanged(int type, int rat) {
+        mIndication.voiceRadioTechChanged(type, rat);
+    }
+
+    public void cellInfoList(int type, ArrayList<android.hardware.radio.V1_0.CellInfo> records) {
+        mIndication.cellInfoList(type, records);
+    }
+
+    public void imsNetworkStateChanged(int type) {
+        mIndication.imsNetworkStateChanged(type);
+    }
+
+    public void subscriptionStatusChanged(int type, boolean activate) {
+        mIndication.subscriptionStatusChanged(type, activate);
+    }
+
+    public void srvccStateNotify(int type, int state) {
+        mIndication.srvccStateNotify(type, state);
+    }
+
+    public void hardwareConfigChanged(int type, ArrayList<android.hardware.radio.V1_0.HardwareConfig> configs) {
+        mIndication.hardwareConfigChanged(type, configs);
+    }
+
+    public void radioCapabilityIndication(int type, android.hardware.radio.V1_0.RadioCapability rc) {
+        mIndication.radioCapabilityIndication(type, rc);
+    }
+
+    public void onSupplementaryServiceIndication(int type, android.hardware.radio.V1_0.StkCcUnsolSsResult ss) {
+        mIndication.onSupplementaryServiceIndication(type, ss);
+    }
+
+    public void stkCallControlAlphaNotify(int type, String alpha) {
+        mIndication.stkCallControlAlphaNotify(type, alpha);
+    }
+
+    public void lceData(int type, android.hardware.radio.V1_0.LceDataInfo lce) {
+        mIndication.lceData(type, lce);
+    }
+
+    public void pcoData(int type, android.hardware.radio.V1_0.PcoDataInfo pco) {
+        mIndication.pcoData(type, pco);
+    }
+
+    public void modemReset(int type, String reason) {
+        mIndication.modemReset(type, reason);
+    }
+    //-- Radio V1_0
+
+    //++ Radio V1_1
+    public void carrierInfoForImsiEncryption(int type) {
+        mIndication.carrierInfoForImsiEncryption(type);
+    }
+
+    public void networkScanResult(int type, android.hardware.radio.V1_1.NetworkScanResult result) {
+        mIndication.networkScanResult(type, result);
+    }
+
+    public void keepaliveStatus(int type, android.hardware.radio.V1_1.KeepaliveStatus status) {
+        mIndication.keepaliveStatus(type, status);
+    }
+
+    //-- Radio V1_1
+
+    //++ MTK Radio V2_0
+    public void incomingCallIndication(int indicationType, IncomingCallNotification notification) {
+        mRil.processIndication(indicationType);
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< incomingCallIndication");
+        mRil.setCallIndication(
+            Integer.parseInt(notification.callId), Integer.parseInt(notification.seqNo));
+    }
+
+    public void cipherIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< cipherIndication not implemented");
+    }
+
+    public void crssIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< crssIndication not implemented");
+    }
+
+    public void vtStatusInfoIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< vtStatusInfoIndication not implemented");
+    }
+
+    public void speechCodecInfoIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< speechCodecInfoIndication not implemented");
+    }
+
+    public void cdmaCallAccepted() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< cdmaCallAccepted not implemented");
+    }
+
+    public void onVirtualSimOn() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onVirtualSimOn not implemented");
+    }
+
+    public void onVirtualSimOff() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onVirtualSimOff not implemented");
+    }
+
+    public void onImeiLock() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onImeiLock not implemented");
+    }
+
+    public void onImsiRefreshDone() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onImsiRefreshDone not implemented");
+    }
+
+    public void newEtwsInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< newEtwsInd not implemented");
+    }
+
+    public void meSmsStorageFullInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< meSmsStorageFullInd not implemented");
+    }
+
+    public void smsReadyInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< smsReadyInd not implemented");
+    }
+
+    public void dataCallListChangedEx(int indicationType,
+        ArrayList<MtkSetupDataCallResult> mtkDcList) {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< dataCallListChangedEx");
+        ArrayList<SetupDataCallResult> dcList = new java.util.ArrayList<SetupDataCallResult>();
+        mtkDcList.forEach(entry -> dcList.add(entry.dcr));
+        mIndication.dataCallListChanged(indicationType, dcList);
+    }
+
+    public void responseCsNetworkStateChangeInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responseCsNetworkStateChangeInd not implemented");
+    }
+
+    public void eMBMSAtInfoIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< eMBMSAtInfoIndication not implemented");
+    }
+
+    public void eMBMSSessionStatusIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< eMBMSSessionStatusIndication not implemented");
+    }
+
+    public void responsePsNetworkStateChangeInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responsePsNetworkStateChangeInd not implemented");
+    }
+
+    public void responseInvalidSimInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responseInvalidSimInd not implemented");
+    }
+
+    public void responseNetworkEventInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responseNetworkEventInd not implemented");
+    }
+
+    public void responseModulationInfoInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responseModulationInfoInd not implemented");
+    }
+
+    public void dataAllowedNotification() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< dataAllowedNotification not implemented");
+    }
+
+    public void onPseudoCellInfoInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onPseudoCellInfoInd not implemented");
+    }
+
+    public void plmnChangedIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< plmnChangedIndication not implemented");
+    }
+
+    public void registrationSuspendedIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< registrationSuspendedIndication not implemented");
+    }
+
+    public void gmssRatChangedIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< gmssRatChangedIndication not implemented");
+    }
+
+    public void worldModeChangedIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< worldModeChangedIndication not implemented");
+    }
+
+    public void resetAttachApnInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< resetAttachApnInd not implemented");
+    }
+
+    public void mdChangedApnInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< mdChangedApnInd not implemented");
+    }
+
+    public void esnMeidChangeInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< esnMeidChangeInd not implemented");
+    }
+
+    public void responseFemtocellInfo() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< responseFemtocellInfo not implemented");
+    }
+
+    public void phbReadyNotification() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< phbReadyNotification not implemented");
+    }
+
+    public void bipProactiveCommand() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< bipProactiveCommand not implemented");
+    }
+
+    public void triggerOtaSP() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< triggerOtaSP not implemented");
+    }
+
+    public void onStkMenuReset() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onStkMenuReset not implemented");
+    }
+
+    public void onMdDataRetryCountReset() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onMdDataRetryCountReset not implemented");
+    }
+
+    public void onRemoveRestrictEutran() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onRemoveRestrictEutran not implemented");
+    }
+
+    public void onPcoStatus() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onPcoStatus not implemented");
+    }
+
+    public void onLteAccessStratumStateChanged() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onLteAccessStratumStateChanged not implemented");
+    }
+
+    public void onSimPlugIn() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimPlugIn not implemented");
+    }
+
+    public void onSimPlugOut() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimPlugOut not implemented");
+    }
+
+    public void onSimMissing() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimMissing not implemented");
+    }
+
+    public void onSimRecovery() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimRecovery not implemented");
+    }
+
+    public void onSimTrayPlugIn() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimTrayPlugIn not implemented");
+    }
+
+    public void onSimCommonSlotNoChanged() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimCommonSlotNoChanged not implemented");
+    }
+
+    public void onSimMeLockEvent() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onSimMeLockEvent not implemented");
+    }
+
+    public void networkInfoInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< networkInfoInd not implemented");
+    }
+
+    public void cfuStatusNotify() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< cfuStatusNotify not implemented");
+    }
+
+    public void pcoDataAfterAttached() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< pcoDataAfterAttached not implemented");
+    }
+
+    public void confSRVCC() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< confSRVCC not implemented");
+    }
+
+    public void onVsimEventIndication() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onVsimEventIndication not implemented");
+    }
+
+    public void volteLteConnectionStatus() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< volteLteConnectionStatus not implemented");
+    }
+
+    public void dedicatedBearerActivationInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< dedicatedBearerActivationInd not implemented");
+    }
+
+    public void dedicatedBearerModificationInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< dedicatedBearerModificationInd not implemented");
+    }
+
+    public void dedicatedBearerDeactivationInd() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< dedicatedBearerDeactivationInd not implemented");
+    }
+
+    public void onWifiMonitoringThreshouldChanged() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onWifiMonitoringThreshouldChanged not implemented");
+    }
+
+    public void onWifiPdnActivate() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onWifiPdnActivate not implemented");
+    }
+
+    public void onWfcPdnError() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onWfcPdnError not implemented");
+    }
+
+    public void onPdnHandover() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onPdnHandover not implemented");
+    }
+
+    public void onWifiRoveout() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onWifiRoveout not implemented");
+    }
+
+    public void onLocationRequest() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onLocationRequest not implemented");
+    }
+
+    public void onWfcPdnStateChanged() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onWfcPdnStateChanged not implemented");
+    }
+
+    public void onNattKeepAliveChanged() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< onNattKeepAliveChanged not implemented");
+    }
+
+    public void oemHookRaw() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[UNSL][MTK]< oemHookRaw not implemented");
+    }
+    //-- MTK Radio V2_0
+}

--- a/src/java/com/android/internal/telephony/MtkRadioResponse.java
+++ b/src/java/com/android/internal/telephony/MtkRadioResponse.java
@@ -1,0 +1,984 @@
+package com.android.internal.telephony;
+
+import android.hardware.radio.V1_0.ActivityStatsInfo;
+import android.hardware.radio.V1_0.CallForwardInfo;
+import android.hardware.radio.V1_0.Call;
+import android.hardware.radio.V1_0.CardStatus;
+import android.hardware.radio.V1_0.CarrierRestrictions;
+import android.hardware.radio.V1_0.CdmaBroadcastSmsConfigInfo;
+import android.hardware.radio.V1_0.CellInfo;
+import android.hardware.radio.V1_0.DataRegStateResult;
+import android.hardware.radio.V1_0.HardwareConfig;
+import android.hardware.radio.V1_0.IccIoResult;
+import android.hardware.radio.V1_0.GsmBroadcastSmsConfigInfo;
+import android.hardware.radio.V1_0.LastCallFailCauseInfo;
+import android.hardware.radio.V1_0.LceDataInfo;
+import android.hardware.radio.V1_0.LceStatusInfo;
+import android.hardware.radio.V1_0.NeighboringCell;
+import android.hardware.radio.V1_0.OperatorInfo;
+import android.hardware.radio.V1_0.RadioCapability;
+import android.hardware.radio.V1_0.RadioResponseInfo;
+import android.hardware.radio.V1_0.SendSmsResult;
+import android.hardware.radio.V1_0.SetupDataCallResult;
+import android.hardware.radio.V1_0.SignalStrength;
+import android.hardware.radio.V1_0.VoiceRegStateResult;
+import android.hardware.radio.V1_1.KeepaliveStatus;
+
+import java.util.ArrayList;
+
+import vendor.mediatek.hardware.radio.V2_0.IRadioResponse;
+import vendor.mediatek.hardware.radio.V2_0.MtkSetupDataCallResult;
+
+public class MtkRadioResponse extends IRadioResponse.Stub {
+    RIL mRil;
+    RadioResponse mResponse;
+
+    MtkRadioResponse(RIL ril, RadioResponse response) {
+      mRil = ril;
+        mResponse = response;
+    }
+
+    //++ Radio V1_0
+    public void getIccCardStatusResponse(RadioResponseInfo info, CardStatus cardStatus) {
+        mResponse.getIccCardStatusResponse(info, cardStatus);
+    }
+    public void supplyIccPinForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.supplyIccPinForAppResponse(info, remainingRetries);
+    }
+
+    public void supplyIccPukForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.supplyIccPukForAppResponse(info, remainingRetries);
+    }
+
+    public void supplyIccPin2ForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.supplyIccPin2ForAppResponse(info, remainingRetries);
+    }
+
+    public void supplyIccPuk2ForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.supplyIccPuk2ForAppResponse(info, remainingRetries);
+    }
+
+    public void changeIccPinForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.changeIccPinForAppResponse(info, remainingRetries);
+    }
+
+    public void changeIccPin2ForAppResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.changeIccPin2ForAppResponse(info, remainingRetries);
+    }
+
+    public void supplyNetworkDepersonalizationResponse(RadioResponseInfo info, int remainingRetries) {
+        mResponse.supplyNetworkDepersonalizationResponse(info, remainingRetries);
+    }
+
+    public void getCurrentCallsResponse(RadioResponseInfo info, ArrayList<Call> calls) {
+        mResponse.getCurrentCallsResponse(info, calls);
+    }
+
+    public void dialResponse(RadioResponseInfo info) {
+        mResponse.dialResponse(info);
+    }
+
+    public void getIMSIForAppResponse(RadioResponseInfo info, String imsi) {
+        mResponse.getIMSIForAppResponse(info, imsi);
+    }
+
+    public void hangupConnectionResponse(RadioResponseInfo info) {
+        mResponse.hangupConnectionResponse(info);
+    }
+
+    public void hangupWaitingOrBackgroundResponse(RadioResponseInfo info) {
+        mResponse.hangupWaitingOrBackgroundResponse(info);
+    }
+
+    public void hangupForegroundResumeBackgroundResponse(RadioResponseInfo info) {
+        mResponse.hangupForegroundResumeBackgroundResponse(info);
+    }
+
+    public void switchWaitingOrHoldingAndActiveResponse(RadioResponseInfo info) {
+        mResponse.switchWaitingOrHoldingAndActiveResponse(info);
+    }
+
+    public void conferenceResponse(RadioResponseInfo info) {
+        mResponse.conferenceResponse(info);
+    }
+
+    public void rejectCallResponse(RadioResponseInfo info) {
+        mResponse.rejectCallResponse(info);
+    }
+
+    public void getLastCallFailCauseResponse(RadioResponseInfo info, LastCallFailCauseInfo failCauseinfo) {
+        mResponse.getLastCallFailCauseResponse(info, failCauseinfo);
+    }
+
+    public void getSignalStrengthResponse(RadioResponseInfo info, SignalStrength sigStrength) {
+        mResponse.getSignalStrengthResponse(info, sigStrength);
+    }
+
+    public void getVoiceRegistrationStateResponse(RadioResponseInfo info, VoiceRegStateResult voiceRegResponse) {
+        mResponse.getVoiceRegistrationStateResponse(info, voiceRegResponse);
+    }
+
+    public void getDataRegistrationStateResponse(RadioResponseInfo info, DataRegStateResult dataRegResponse) {
+        mResponse.getDataRegistrationStateResponse(info, dataRegResponse);
+    }
+
+    public void getOperatorResponse(RadioResponseInfo info, String longName, String shortName, String numeric) {
+        mResponse.getOperatorResponse(info, longName, shortName, numeric);
+    }
+
+    public void setRadioPowerResponse(RadioResponseInfo info) {
+        mResponse.setRadioPowerResponse(info);
+    }
+
+    public void sendDtmfResponse(RadioResponseInfo info) {
+        mResponse.sendDtmfResponse(info);
+    }
+
+    public void sendSmsResponse(RadioResponseInfo info, SendSmsResult sms) {
+        mResponse.sendSmsResponse(info, sms);
+    }
+
+    public void sendSMSExpectMoreResponse(RadioResponseInfo info, SendSmsResult sms) {
+        mResponse.sendSMSExpectMoreResponse(info, sms);
+    }
+
+    public void setupDataCallResponse(RadioResponseInfo info, SetupDataCallResult dcResponse) {
+        mResponse.setupDataCallResponse(info, dcResponse);
+    }
+
+    public void iccIOForAppResponse(RadioResponseInfo info, IccIoResult iccIo) {
+        mResponse.iccIOForAppResponse(info, iccIo);
+    }
+
+    public void sendUssdResponse(RadioResponseInfo info) {
+        mResponse.sendUssdResponse(info);
+    }
+
+    public void cancelPendingUssdResponse(RadioResponseInfo info) {
+        mResponse.cancelPendingUssdResponse(info);
+    }
+
+    public void getClirResponse(RadioResponseInfo info, int n, int m) {
+        mResponse.getClirResponse(info, n, m);
+    }
+
+    public void setClirResponse(RadioResponseInfo info) {
+        mResponse.setClirResponse(info);
+    }
+
+    public void getCallForwardStatusResponse(RadioResponseInfo info, ArrayList<CallForwardInfo> callForwardInfos) {
+        mResponse.getCallForwardStatusResponse(info, callForwardInfos);
+    }
+
+    public void setCallForwardResponse(RadioResponseInfo info) {
+        mResponse.setCallForwardResponse(info);
+    }
+
+    public void getCallWaitingResponse(RadioResponseInfo info, boolean enable, int serviceClass) {
+        mResponse.getCallWaitingResponse(info, enable, serviceClass);
+    }
+
+    public void setCallWaitingResponse(RadioResponseInfo info) {
+        mResponse.setCallWaitingResponse(info);
+    }
+
+    public void acknowledgeLastIncomingGsmSmsResponse(RadioResponseInfo info) {
+        mResponse.acknowledgeLastIncomingGsmSmsResponse(info);
+    }
+
+    public void acceptCallResponse(RadioResponseInfo info) {
+        mResponse.acceptCallResponse(info);
+    }
+
+    public void deactivateDataCallResponse(RadioResponseInfo info) {
+        mResponse.deactivateDataCallResponse(info);
+    }
+
+    public void getFacilityLockForAppResponse(RadioResponseInfo info, int response) {
+        mResponse.getFacilityLockForAppResponse(info, response);
+    }
+
+    public void setFacilityLockForAppResponse(RadioResponseInfo info, int retry) {
+        mResponse.setFacilityLockForAppResponse(info, retry);
+    }
+
+    public void setBarringPasswordResponse(RadioResponseInfo info) {
+        mResponse.setBarringPasswordResponse(info);
+    }
+
+    public void getNetworkSelectionModeResponse(RadioResponseInfo info, boolean manual) {
+        mResponse.getNetworkSelectionModeResponse(info, manual);
+    }
+
+    public void setNetworkSelectionModeAutomaticResponse(RadioResponseInfo info) {
+        mResponse.setNetworkSelectionModeAutomaticResponse(info);
+    }
+
+    public void setNetworkSelectionModeManualResponse(RadioResponseInfo info) {
+        mResponse.setNetworkSelectionModeManualResponse(info);
+    }
+
+    public void getAvailableNetworksResponse(RadioResponseInfo info, ArrayList<OperatorInfo> networkInfos) {
+        mResponse.getAvailableNetworksResponse(info, networkInfos);
+    }
+
+    public void startDtmfResponse(RadioResponseInfo info) {
+        mResponse.startDtmfResponse(info);
+    }
+
+    public void stopDtmfResponse(RadioResponseInfo info) {
+        mResponse.stopDtmfResponse(info);
+    }
+
+    public void getBasebandVersionResponse(RadioResponseInfo info, String version) {
+        mResponse.getBasebandVersionResponse(info, version);
+    }
+
+    public void separateConnectionResponse(RadioResponseInfo info) {
+        mResponse.separateConnectionResponse(info);
+    }
+
+    public void setMuteResponse(RadioResponseInfo info) {
+        mResponse.setMuteResponse(info);
+    }
+
+    public void getMuteResponse(RadioResponseInfo info, boolean enable) {
+        mResponse.getMuteResponse(info, enable);
+    }
+
+    public void getClipResponse(RadioResponseInfo info, int status) {
+        mResponse.getClipResponse(info, status);
+    }
+
+    public void getDataCallListResponse(RadioResponseInfo info, ArrayList<SetupDataCallResult> dcResponse) {
+        mResponse.getDataCallListResponse(info, dcResponse);
+    }
+
+    public void setSuppServiceNotificationsResponse(RadioResponseInfo info) {
+        mResponse.setSuppServiceNotificationsResponse(info);
+    }
+
+    public void writeSmsToSimResponse(RadioResponseInfo info, int index) {
+        mResponse.writeSmsToSimResponse(info, index);
+    }
+
+    public void deleteSmsOnSimResponse(RadioResponseInfo info) {
+        mResponse.deleteSmsOnSimResponse(info);
+    }
+
+    public void setBandModeResponse(RadioResponseInfo info) {
+        mResponse.setBandModeResponse(info);
+    }
+
+    public void getAvailableBandModesResponse(RadioResponseInfo info, ArrayList<Integer> bandModes) {
+        mResponse.getAvailableBandModesResponse(info, bandModes);
+    }
+
+    public void sendEnvelopeResponse(RadioResponseInfo info, String commandResponse) {
+        mResponse.sendEnvelopeResponse(info, commandResponse);
+    }
+
+    public void sendTerminalResponseToSimResponse(RadioResponseInfo info) {
+        mResponse.sendTerminalResponseToSimResponse(info);
+    }
+
+    public void handleStkCallSetupRequestFromSimResponse(RadioResponseInfo info) {
+        mResponse.handleStkCallSetupRequestFromSimResponse(info);
+    }
+
+    public void explicitCallTransferResponse(RadioResponseInfo info) {
+        mResponse.explicitCallTransferResponse(info);
+    }
+
+    public void setPreferredNetworkTypeResponse(RadioResponseInfo info) {
+        mResponse.setPreferredNetworkTypeResponse(info);
+    }
+
+    public void getPreferredNetworkTypeResponse(RadioResponseInfo info, int nwType) {
+        mResponse.getPreferredNetworkTypeResponse(info, nwType);
+    }
+
+    public void getNeighboringCidsResponse(RadioResponseInfo info, ArrayList<NeighboringCell> cells) {
+        mResponse.getNeighboringCidsResponse(info, cells);
+    }
+
+    public void setLocationUpdatesResponse(RadioResponseInfo info) {
+        mResponse.setLocationUpdatesResponse(info);
+    }
+
+    public void setCdmaSubscriptionSourceResponse(RadioResponseInfo info) {
+        mResponse.setCdmaSubscriptionSourceResponse(info);
+    }
+
+    public void setCdmaRoamingPreferenceResponse(RadioResponseInfo info) {
+        mResponse.setCdmaRoamingPreferenceResponse(info);
+    }
+
+    public void getCdmaRoamingPreferenceResponse(RadioResponseInfo info, int type) {
+        mResponse.getCdmaRoamingPreferenceResponse(info, type);
+    }
+
+    public void setTTYModeResponse(RadioResponseInfo info) {
+        mResponse.setTTYModeResponse(info);
+    }
+
+    public void getTTYModeResponse(RadioResponseInfo info, int mode) {
+        mResponse.getTTYModeResponse(info, mode);
+    }
+
+    public void setPreferredVoicePrivacyResponse(RadioResponseInfo info) {
+        mResponse.setPreferredVoicePrivacyResponse(info);
+    }
+
+    public void getPreferredVoicePrivacyResponse(RadioResponseInfo info, boolean enable) {
+        mResponse.getPreferredVoicePrivacyResponse(info, enable);
+    }
+
+    public void sendCDMAFeatureCodeResponse(RadioResponseInfo info) {
+        mResponse.sendCDMAFeatureCodeResponse(info);
+    }
+
+    public void sendBurstDtmfResponse(RadioResponseInfo info) {
+        mResponse.sendBurstDtmfResponse(info);
+    }
+
+    public void sendCdmaSmsResponse(RadioResponseInfo info, SendSmsResult sms) {
+        mResponse.sendCdmaSmsResponse(info, sms);
+    }
+
+    public void acknowledgeLastIncomingCdmaSmsResponse(RadioResponseInfo info) {
+        mResponse.acknowledgeLastIncomingCdmaSmsResponse(info);
+    }
+
+    public void getGsmBroadcastConfigResponse(RadioResponseInfo info, ArrayList<GsmBroadcastSmsConfigInfo> configs) {
+        mResponse.getGsmBroadcastConfigResponse(info, configs);
+    }
+
+    public void setGsmBroadcastConfigResponse(RadioResponseInfo info) {
+        mResponse.setGsmBroadcastConfigResponse(info);
+    }
+
+    public void setGsmBroadcastActivationResponse(RadioResponseInfo info) {
+        mResponse.setGsmBroadcastActivationResponse(info);
+    }
+
+    public void getCdmaBroadcastConfigResponse(RadioResponseInfo info, ArrayList<CdmaBroadcastSmsConfigInfo> configs) {
+        mResponse.getCdmaBroadcastConfigResponse(info, configs);
+    }
+
+    public void setCdmaBroadcastConfigResponse(RadioResponseInfo info) {
+        mResponse.setCdmaBroadcastConfigResponse(info);
+    }
+
+    public void setCdmaBroadcastActivationResponse(RadioResponseInfo info) {
+        mResponse.setCdmaBroadcastActivationResponse(info);
+    }
+
+    public void getCDMASubscriptionResponse(RadioResponseInfo info, String mdn, String hSid, String hNid, String min, String prl) {
+        mResponse.getCDMASubscriptionResponse(info, mdn, hSid, hNid, min, prl);
+    }
+
+    public void writeSmsToRuimResponse(RadioResponseInfo info, int index) {
+        mResponse.writeSmsToRuimResponse(info, index);
+    }
+
+    public void deleteSmsOnRuimResponse(RadioResponseInfo info) {
+        mResponse.deleteSmsOnRuimResponse(info);
+    }
+
+    public void getDeviceIdentityResponse(RadioResponseInfo info, String imei, String imeisv, String esn, String meid) {
+        mResponse.getDeviceIdentityResponse(info, imei, imeisv, esn, meid);
+    }
+
+    public void exitEmergencyCallbackModeResponse(RadioResponseInfo info) {
+        mResponse.exitEmergencyCallbackModeResponse(info);
+    }
+
+    public void getSmscAddressResponse(RadioResponseInfo info, String smsc) {
+        mResponse.getSmscAddressResponse(info, smsc);
+    }
+
+    public void setSmscAddressResponse(RadioResponseInfo info) {
+        mResponse.setSmscAddressResponse(info);
+    }
+
+    public void reportSmsMemoryStatusResponse(RadioResponseInfo info) {
+        mResponse.reportSmsMemoryStatusResponse(info);
+    }
+
+    public void reportStkServiceIsRunningResponse(RadioResponseInfo info) {
+        mResponse.reportStkServiceIsRunningResponse(info);
+    }
+
+    public void getCdmaSubscriptionSourceResponse(RadioResponseInfo info, int source) {
+        mResponse.getCdmaSubscriptionSourceResponse(info, source);
+    }
+
+    public void requestIsimAuthenticationResponse(RadioResponseInfo info, String response) {
+        mResponse.requestIsimAuthenticationResponse(info, response);
+    }
+
+    public void acknowledgeIncomingGsmSmsWithPduResponse(RadioResponseInfo info) {
+        mResponse.acknowledgeIncomingGsmSmsWithPduResponse(info);
+    }
+
+    public void sendEnvelopeWithStatusResponse(RadioResponseInfo info, IccIoResult iccIo) {
+        mResponse.sendEnvelopeWithStatusResponse(info, iccIo);
+    }
+
+    public void getVoiceRadioTechnologyResponse(RadioResponseInfo info, int rat) {
+        mResponse.getVoiceRadioTechnologyResponse(info, rat);
+    }
+
+    public void getCellInfoListResponse(RadioResponseInfo info, ArrayList<CellInfo> cellInfo) {
+        mResponse.getCellInfoListResponse(info, cellInfo);
+    }
+
+    public void setCellInfoListRateResponse(RadioResponseInfo info) {
+        mResponse.setCellInfoListRateResponse(info);
+    }
+
+    public void setInitialAttachApnResponse(RadioResponseInfo info) {
+        mResponse.setInitialAttachApnResponse(info);
+    }
+
+    public void getImsRegistrationStateResponse(RadioResponseInfo info, boolean isRegistered, int ratFamily) {
+        mResponse.getImsRegistrationStateResponse(info, isRegistered, ratFamily);
+    }
+
+    public void sendImsSmsResponse(RadioResponseInfo info, SendSmsResult sms) {
+        mResponse.sendImsSmsResponse(info, sms);
+    }
+
+    public void iccTransmitApduBasicChannelResponse(RadioResponseInfo info, IccIoResult result) {
+        mResponse.iccTransmitApduBasicChannelResponse(info, result);
+    }
+
+    public void iccOpenLogicalChannelResponse(RadioResponseInfo info, int channelId, ArrayList<Byte> selectResponse) {
+        mResponse.iccOpenLogicalChannelResponse(info, channelId, selectResponse);
+    }
+
+    public void iccCloseLogicalChannelResponse(RadioResponseInfo info) {
+        mResponse.iccCloseLogicalChannelResponse(info);
+    }
+
+    public void iccTransmitApduLogicalChannelResponse(RadioResponseInfo info, IccIoResult result) {
+        mResponse.iccTransmitApduLogicalChannelResponse(info, result);
+    }
+
+    public void nvReadItemResponse(RadioResponseInfo info, String result) {
+        mResponse.nvReadItemResponse(info, result);
+    }
+
+    public void nvWriteItemResponse(RadioResponseInfo info) {
+        mResponse.nvWriteItemResponse(info);
+    }
+
+    public void nvWriteCdmaPrlResponse(RadioResponseInfo info) {
+        mResponse.nvWriteCdmaPrlResponse(info);
+    }
+
+    public void nvResetConfigResponse(RadioResponseInfo info) {
+        mResponse.nvResetConfigResponse(info);
+    }
+
+    public void setUiccSubscriptionResponse(RadioResponseInfo info) {
+        mResponse.setUiccSubscriptionResponse(info);
+    }
+
+    public void setDataAllowedResponse(RadioResponseInfo info) {
+        mResponse.setDataAllowedResponse(info);
+    }
+
+    public void getHardwareConfigResponse(RadioResponseInfo info, ArrayList<HardwareConfig> config) {
+        mResponse.getHardwareConfigResponse(info, config);
+    }
+
+    public void requestIccSimAuthenticationResponse(RadioResponseInfo info, IccIoResult result) {
+        mResponse.requestIccSimAuthenticationResponse(info, result);
+    }
+
+    public void setDataProfileResponse(RadioResponseInfo info) {
+        mResponse.setDataProfileResponse(info);
+    }
+
+    public void requestShutdownResponse(RadioResponseInfo info) {
+        mResponse.requestShutdownResponse(info);
+    }
+
+    public void getRadioCapabilityResponse(RadioResponseInfo info, RadioCapability rc) {
+        mResponse.getRadioCapabilityResponse(info, rc);
+    }
+
+    public void setRadioCapabilityResponse(RadioResponseInfo info, RadioCapability rc) {
+        mResponse.setRadioCapabilityResponse(info, rc);
+    }
+
+    public void startLceServiceResponse(RadioResponseInfo info, LceStatusInfo statusInfo) {
+        mResponse.startLceServiceResponse(info, statusInfo);
+    }
+
+    public void stopLceServiceResponse(RadioResponseInfo info, LceStatusInfo statusInfo) {
+        mResponse.stopLceServiceResponse(info, statusInfo);
+    }
+
+    public void pullLceDataResponse(RadioResponseInfo info, LceDataInfo lceInfo) {
+        mResponse.pullLceDataResponse(info, lceInfo);
+    }
+
+    public void getModemActivityInfoResponse(RadioResponseInfo info, ActivityStatsInfo activityInfo) {
+        mResponse.getModemActivityInfoResponse(info, activityInfo);
+    }
+
+    public void setAllowedCarriersResponse(RadioResponseInfo info, int numAllowed) {
+        mResponse.setAllowedCarriersResponse(info, numAllowed);
+    }
+
+    public void getAllowedCarriersResponse(RadioResponseInfo info, boolean allAllowed, CarrierRestrictions carriers) {
+        mResponse.getAllowedCarriersResponse(info, allAllowed, carriers);
+    }
+
+    public void sendDeviceStateResponse(RadioResponseInfo info) {
+        mResponse.sendDeviceStateResponse(info);
+    }
+
+    public void setIndicationFilterResponse(RadioResponseInfo info) {
+        mResponse.setIndicationFilterResponse(info);
+    }
+
+    public void setSimCardPowerResponse(RadioResponseInfo info) {
+        mResponse.setSimCardPowerResponse(info);
+    }
+
+    public void acknowledgeRequest(int serial) {
+        mResponse.acknowledgeRequest(serial);
+    }
+    //-- Radio V1_0
+
+    //++ Radio V1_1
+    public void setCarrierInfoForImsiEncryptionResponse(RadioResponseInfo info) {
+        mResponse.setCarrierInfoForImsiEncryptionResponse(info);
+    }
+
+    public void setSimCardPowerResponse_1_1(RadioResponseInfo info) {
+        mResponse.setSimCardPowerResponse_1_1(info);
+    }
+
+    public void startNetworkScanResponse(RadioResponseInfo info) {
+        mResponse.startNetworkScanResponse(info);
+    }
+
+    public void stopNetworkScanResponse(RadioResponseInfo info) {
+        mResponse.stopNetworkScanResponse(info);
+    }
+
+    public void startKeepaliveResponse(RadioResponseInfo info, KeepaliveStatus status) {
+        mResponse.startKeepaliveResponse(info, status);
+    }
+
+    public void stopKeepaliveResponse(RadioResponseInfo info) {
+        mResponse.stopKeepaliveResponse(info);
+    }
+    //-- Radio V1_1
+
+    //++ MTK Radio V2_0
+    public void setTrmResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setTrmResponse not implemented");
+    }
+
+    public void getATRResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getATRResponse not implemented");
+    }
+
+    public void setSimPowerResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setSimPowerResponse not implemented");
+    }
+
+    public void setModemPowerResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setModemPowerResponse not implemented");
+    }
+
+    public void hangupAllResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< hangupAllResponse not implemented");
+    }
+
+    public void setCallIndicationResponse(RadioResponseInfo info) {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setCallIndicationResponse");
+      mResponse.responseVoid(info);
+    }
+
+    public void emergencyDialResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< emergencyDialResponse not implemented");
+    }
+
+    public void setEccServiceCategoryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setEccServiceCategoryResponse not implemented");
+    }
+
+    public void setEccListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setEccListResponse not implemented");
+    }
+
+    public void vtDialResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< vtDialResponse not implemented");
+    }
+
+    public void voiceAcceptResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< voiceAcceptResponse not implemented");
+    }
+
+    public void replaceVtCallResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< replaceVtCallResponse not implemented");
+    }
+
+    public void setNetworkSelectionModeManualWithActResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setNetworkSelectionModeManualWithActResponse not implemented");
+    }
+
+    public void getAvailableNetworksWithActResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getAvailableNetworksWithActResponse not implemented");
+    }
+
+    public void cancelAvailableNetworksResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< cancelAvailableNetworksResponse not implemented");
+    }
+
+    public void currentStatusResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< currentStatusResponse not implemented");
+    }
+
+    public void eccPreferredRatResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< eccPreferredRatResponse not implemented");
+    }
+
+    public void getSmsParametersResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getSmsParametersResponse not implemented");
+    }
+
+    public void setSmsParametersResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setSmsParametersResponse not implemented");
+    }
+
+    public void getSmsMemStatusResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getSmsMemStatusResponse not implemented");
+    }
+
+    public void setEtwsResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setEtwsResponse not implemented");
+    }
+
+    public void removeCbMsgResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< removeCbMsgResponse not implemented");
+    }
+
+    public void setGsmBroadcastLangsResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setGsmBroadcastLangsResponse not implemented");
+    }
+
+    public void getGsmBroadcastLangsResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getGsmBroadcastLangsResponse not implemented");
+    }
+
+    public void getGsmBroadcastActivationRsp() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getGsmBroadcastActivationRsp not implemented");
+    }
+
+    public void sendEmbmsAtCommandResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< sendEmbmsAtCommandResponse not implemented");
+    }
+
+    public void setupDataCallResponseEx(RadioResponseInfo responseInfo,
+        MtkSetupDataCallResult setupDataCallResult) {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setupDataCallResponse");
+        mResponse.setupDataCallResponse(responseInfo, setupDataCallResult.dcr);
+    }
+
+    public void getDataCallListResponseEx(RadioResponseInfo info,
+        ArrayList<MtkSetupDataCallResult> mtkDcList) {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getDataCallListResponseEx");
+        ArrayList<SetupDataCallResult> dcList = new ArrayList<SetupDataCallResult>();
+        mtkDcList.forEach(entry -> dcList.add(entry.dcr));
+        mResponse.getDataCallListResponse(info, dcList);
+    }
+
+    public void setApcModeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setApcModeResponse not implemented");
+    }
+
+    public void getApcInfoResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getApcInfoResponse not implemented");
+    }
+
+    public void triggerModeSwitchByEccResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< triggerModeSwitchByEccResponse not implemented");
+    }
+
+    public void getSmsRuimMemoryStatusResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getSmsRuimMemoryStatusResponse not implemented");
+    }
+
+    public void setFdModeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setFdModeResponse not implemented");
+    }
+
+    public void setResumeRegistrationResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setResumeRegistrationResponse not implemented");
+    }
+
+    public void storeModemTypeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< storeModemTypeResponse not implemented");
+    }
+
+    public void reloadModemTypeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< reloadModemTypeResponse not implemented");
+    }
+
+    public void handleStkCallSetupRequestFromSimWithResCodeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< handleStkCallSetupRequestFromSimWithResCodeResponse not implemented");
+    }
+
+    public void getFemtocellListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getFemtocellListResponse not implemented");
+    }
+
+    public void abortFemtocellListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< abortFemtocellListResponse not implemented");
+    }
+
+    public void selectFemtocellResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< selectFemtocellResponse not implemented");
+    }
+
+    public void queryFemtoCellSystemSelectionModeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryFemtoCellSystemSelectionModeResponse not implemented");
+    }
+
+    public void setFemtoCellSystemSelectionModeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setFemtoCellSystemSelectionModeResponse not implemented");
+    }
+
+    public void setClipResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setClipResponse not implemented");
+    }
+
+    public void getColpResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getColpResponse not implemented");
+    }
+
+    public void getColrResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getColrResponse not implemented");
+    }
+
+    public void sendCnapResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< sendCnapResponse not implemented");
+    }
+
+    public void setColpResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setColpResponse not implemented");
+    }
+
+    public void setColrResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setColrResponse not implemented");
+    }
+
+    public void queryCallForwardInTimeSlotStatusResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryCallForwardInTimeSlotStatusResponse not implemented");
+    }
+
+    public void setCallForwardInTimeSlotResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setCallForwardInTimeSlotResponse not implemented");
+    }
+
+    public void runGbaAuthenticationResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< runGbaAuthenticationResponse not implemented");
+    }
+
+    public void queryPhbStorageInfoResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryPhbStorageInfoResponse not implemented");
+    }
+
+    public void writePhbEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< writePhbEntryResponse not implemented");
+    }
+
+    public void readPhbEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readPhbEntryResponse not implemented");
+    }
+
+    public void queryUPBCapabilityResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryUPBCapabilityResponse not implemented");
+    }
+
+    public void editUPBEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< editUPBEntryResponse not implemented");
+    }
+
+    public void deleteUPBEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< deleteUPBEntryResponse not implemented");
+    }
+
+    public void readUPBGasListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBGasListResponse not implemented");
+    }
+
+    public void readUPBGrpEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBGrpEntryResponse not implemented");
+    }
+
+    public void writeUPBGrpEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< writeUPBGrpEntryResponse not implemented");
+    }
+
+    public void getPhoneBookStringsLengthResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getPhoneBookStringsLengthResponse not implemented");
+    }
+
+    public void getPhoneBookMemStorageResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getPhoneBookMemStorageResponse not implemented");
+    }
+
+    public void setPhoneBookMemStorageResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setPhoneBookMemStorageResponse not implemented");
+    }
+
+    public void readPhoneBookEntryExtResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readPhoneBookEntryExtResponse not implemented");
+    }
+
+    public void writePhoneBookEntryExtResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< writePhoneBookEntryExtResponse not implemented");
+    }
+
+    public void queryUPBAvailableResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryUPBAvailableResponse not implemented");
+    }
+
+    public void readUPBEmailEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBEmailEntryResponse not implemented");
+    }
+
+    public void readUPBSneEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBSneEntryResponse not implemented");
+    }
+
+    public void readUPBAnrEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBAnrEntryResponse not implemented");
+    }
+
+    public void readUPBAasListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< readUPBAasListResponse not implemented");
+    }
+
+    public void queryNetworkLockResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< queryNetworkLockResponse not implemented");
+    }
+
+    public void setNetworkLockResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setNetworkLockResponse not implemented");
+    }
+
+    public void resetRadioResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< resetRadioResponse not implemented");
+    }
+
+    public void syncDataSettingsToMdResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< syncDataSettingsToMdResponse not implemented");
+    }
+
+    public void resetMdDataRetryCountResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< resetMdDataRetryCountResponse not implemented");
+    }
+
+    public void setRemoveRestrictEutranModeResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setRemoveRestrictEutranModeResponse not implemented");
+    }
+
+    public void setLteAccessStratumReportResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setLteAccessStratumReportResponse not implemented");
+    }
+
+    public void setLteUplinkDataTransferResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setLteUplinkDataTransferResponse not implemented");
+    }
+
+    public void setRxTestConfigResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setRxTestConfigResponse not implemented");
+    }
+
+    public void getRxTestResultResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getRxTestResultResponse not implemented");
+    }
+
+    public void getPOLCapabilityResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getPOLCapabilityResponse not implemented");
+    }
+
+    public void getCurrentPOLListResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getCurrentPOLListResponse not implemented");
+    }
+
+    public void setPOLEntryResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setPOLEntryResponse not implemented");
+    }
+
+    public void setRoamingEnableResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setRoamingEnableResponse not implemented");
+    }
+
+    public void getRoamingEnableResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< getRoamingEnableResponse not implemented");
+    }
+
+    public void vsimNotificationResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< vsimNotificationResponse not implemented");
+    }
+
+    public void vsimOperationResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< vsimOperationResponse not implemented");
+    }
+
+    public void setWifiEnabledResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setWifiEnabledResponse not implemented");
+    }
+
+    public void setWifiAssociatedResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setWifiAssociatedResponse not implemented");
+    }
+
+    public void setWifiSignalLevelResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setWifiSignalLevelResponse not implemented");
+    }
+
+    public void setWifiIpAddressResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setWifiIpAddressResponse not implemented");
+    }
+
+    public void setLocationInfoResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setLocationInfoResponse not implemented");
+    }
+
+    public void setEmergencyAddressIdResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setEmergencyAddressIdResponse not implemented");
+    }
+
+    public void setNattKeepAliveStatusResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setNattKeepAliveStatusResponse not implemented");
+    }
+
+    public void setE911StateResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setE911StateResponse not implemented");
+    }
+
+    public void setServiceStateToModemResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< setServiceStateToModemResponse not implemented");
+    }
+
+    public void sendRequestRawResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< sendRequestRawResponse not implemented");
+    }
+
+    public void sendRequestStringsResponse() {
+        if (RIL.RILJ_LOGD) mRil.riljLog("[MTK]< sendRequestStringsResponse not implemented");
+    }
+    //-- MTK Radio V2_0
+}

--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -340,6 +340,9 @@ public final class RIL extends BaseCommands implements CommandsInterface {
     final AtomicLong mRadioProxyCookie = new AtomicLong(0);
     final RadioProxyDeathRecipient mRadioProxyDeathRecipient;
     final RilHandler mRilHandler;
+    vendor.mediatek.hardware.radio.V2_0.IRadioResponse mMtkRadioResponse;
+    vendor.mediatek.hardware.radio.V2_0.IRadioIndication mMtkRadioIndication;
+    volatile vendor.mediatek.hardware.radio.V2_0.IRadio mMtkRadioProxy = null;
 
     //***** Events
     static final int EVENT_WAKE_LOCK_TIMEOUT    = 2;
@@ -539,6 +542,23 @@ public final class RIL extends BaseCommands implements CommandsInterface {
                     mRilHandler.obtainMessage(EVENT_RADIO_PROXY_DEAD,
                             mRadioProxyCookie.incrementAndGet()),
                     IRADIO_GET_SERVICE_DELAY_MILLIS);
+        }
+
+        if (mRadioProxy != null) {
+            try {
+                mMtkRadioProxy =
+                        vendor.mediatek.hardware.radio.V2_0.IRadio.getService(
+                                HIDL_SERVICE_NAME[mPhoneId == null ? 0 : mPhoneId]);
+                if (mMtkRadioProxy != null) {
+                    if (mMtkRadioResponse == null && mMtkRadioIndication == null) {
+                            mMtkRadioResponse = new MtkRadioResponse(this, mRadioResponse);
+                            mMtkRadioIndication = new MtkRadioIndication(this, mRadioIndication);
+                    }
+                    mMtkRadioProxy.setResponseFunctionsMtk(mMtkRadioResponse, mMtkRadioIndication);
+                }
+            } catch (RemoteException | RuntimeException e) {
+                riljLog("MTK RadioProxy is not available");
+            }
         }
 
         return mRadioProxy;
@@ -5206,5 +5226,24 @@ public final class RIL extends BaseCommands implements CommandsInterface {
                 signalStrength.lte.cqi,
                 signalStrength.tdScdma.rscp,
                 false /* gsmFlag - don't care; will be changed by SST */);
+    }
+
+    void setCallIndication(int callId, int seqNo) {
+        // Ensure that mMtkRadioProxy is updated.
+        IRadio radioProxy = getRadioProxy(null);
+        if (mMtkRadioProxy != null) {
+            RILRequest rr = obtainRequest(-1, null, mRILDefaultWorkSource);
+
+            if (RILJ_LOGD) {
+                riljLog(rr.serialString() + "> " + "setCallIndication");
+            }
+
+            try {
+                mMtkRadioProxy.setCallIndication(
+                        rr.mSerial, 0 /* 0: allowed, 1: disallowed */, callId, seqNo);
+            } catch (RemoteException | RuntimeException e) {
+                handleRadioProxyExceptionForRR(rr, "setCallIndication", e);
+            }
+        }
     }
 }

--- a/src/java/com/android/internal/telephony/RadioResponse.java
+++ b/src/java/com/android/internal/telephony/RadioResponse.java
@@ -1377,7 +1377,7 @@ public class RadioResponse extends IRadioResponse.Stub {
         }
     }
 
-    private void responseVoid(RadioResponseInfo responseInfo) {
+    void responseVoid(RadioResponseInfo responseInfo) {
         RILRequest rr = mRil.processResponse(responseInfo);
 
         if (rr != null) {


### PR DESCRIPTION
This is an alternative solution of `s/AT+EAIC=2/AT+EAIC=3/g` in device/phh/treble/rw-system.sh
which is not workable on some MTK devices such as Nokia 1.
Make sure that the solution in `rw-system.sh` is reversed if this alternative is applied.

Here is the reason of each API to be reverse-engineered in this patch:
1. IRadio::setResponseFunctionsMtk():
   - To register callbacks of MTK-extended radio indications and responses.
2. IRadioIndication::incomingCallIndication():
   - To receive the indication of the incoming call to be approved.
3. IRadio::setCallIndication() |
   IRadioResponse::setCallIndicationResponse():
   - To approve each the incoming call reported from incomingCallIndication().
4. IRadioResponse::setupDataCallResponseEx() |
   IRadioResponse::getDataCallListResponseEx() |
   IRadioIndication::dataCallListChangedEx():
   - These callbacks are MTK's replacements of the following AOSP callbacks:
     setupDataCallResponse(), getDataCallListResponse(), dataCallListChanged() if
     MTK-specific implementation is registered via IRadio::setResponseFunctionsMtk().
   - To make sure that data connections are workable after fixing the incoming call issues,
     we have to implement these methods additionally to forward the responses to the replaced ones defined by AOSP.