### PR TITLE
telephony: forward-port support for forceCognitive

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -3963,7 +3963,8 @@ public class RIL extends BaseCommands implements CommandsInterface {
                     for (DataProfile dp : dps) {
                         // For v1.0 to v1.2, we only send data profiles that has the persistent
                         // (a.k.a modem cognitive) bit set to true.
-                        if (dp.isPersistent()) {
+                        boolean forceCognitive = SystemProperties.getBoolean("persist.sys.phh.radio.force_cognitive", false);
+                        if (dp.isPersistent() || forceCognitive) {
                             dpis.add(convertToHalDataProfile10(dp));
                         }
                     }

--- a/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
@@ -1890,8 +1890,9 @@ public class DcTracker extends Handler {
         }
 
         // profile id is only meaningful when the profile is persistent on the modem.
+        boolean forceCognitive = SystemProperties.getBoolean("persist.sys.phh.radio.force_cognitive", false);
         int profileId = DATA_PROFILE_INVALID;
-        if (apnSetting.isPersistent()) {
+        if (apnSetting.isPersistent() || forceCognitive) {
             profileId = apnSetting.getProfileId();
             if (profileId == DATA_PROFILE_DEFAULT) {
                 profileId = getApnProfileID(apnContext.getApnType());


### PR DESCRIPTION
* This is needed on some MTK devices. Android 10 refactored some code,
  so now the "non-persistent/cognitive" filter is relocated to RIL and
  also in DcTracker.setupData().