### PR TITLE
Fix sending of SMS on P/Q/R IMS packages

### DIFF
--- a/src/java/com/android/internal/telephony/metrics/TelephonyMetrics.java
+++ b/src/java/com/android/internal/telephony/metrics/TelephonyMetrics.java
@@ -2312,6 +2312,19 @@ public class TelephonyMetrics {
     }
 
     /**
+     * Write Send SMS event (backwards-compatible method for R and earlier IMS implementations)
+     *
+     * @param phoneId Phone id
+     * @param rilSerial RIL request serial number
+     * @param tech SMS RAT
+     * @param format SMS format. Either {@link SmsMessage#FORMAT_3GPP} or
+     *         {@link SmsMessage#FORMAT_3GPP2}.
+     */
+    public void writeRilSendSms(int phoneId, int rilSerial, int tech, int format) {
+    	writeRilSendSms(phoneId, rilSerial, tech, format, 0);
+    }
+
+    /**
      * Write Send SMS event using ImsService. Expecting response from
      * {@link #writeOnSmsSolicitedResponse}.
      *


### PR DESCRIPTION
Reintroduce 'public void TelephonyMetrics.writeRilSendSms(int, int, int, int)'.

The MediaTek IMS package for Android Q, at the very least (likely for the rest, too)
invoke this method in their `sendSms` method; Google, in their infinite wisdom,
decided that this method needed a message ID passed in as well, changing the signature
to 'public void TelephonyMetrics.writeRilSendSms(int, int, int, int, long)' and resulting
in a MethodNotFoundException being raised in com.mediatek.ims, crashing it.

Fixes https://github.com/phhusson/treble_experimentations/issues/2125.